### PR TITLE
Add Orleans seat locking sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# OpenAIEnvironment
+# Ticket Availability Sample
+
+This repository contains a simple ASP.NET Core application using the Orleans framework to manage seat availability in-memory. It demonstrates how to offload seat locking logic from a database to Orleans grains with an in-memory cache.
+
+## Running the application
+
+Ensure you have the .NET 8 SDK installed. From the repository root run:
+
+```bash
+# restore and run the web application
+dotnet run --project TicketAvailability.Web
+```
+
+The API exposes endpoints to check availability, lock and unlock seats:
+
+- `GET /seats/{eventId}/{seatId}` – returns the availability of a seat.
+- `POST /seats/{eventId}/{seatId}/lock` – attempts to lock the seat (returns 200 on success or 409 when already locked).
+- `POST /seats/{eventId}/{seatId}/unlock` – unlocks the seat.
+
+Swagger UI is enabled during development at `https://localhost:5001/swagger`.
+
+## Running tests
+
+Execute all unit and integration tests with:
+
+```bash
+dotnet test TicketAvailability.sln
+```
+
+The tests include scenarios with high contention to ensure only one lock succeeds when many requests compete for the same seat.

--- a/TicketAvailability.Tests/GlobalUsings.cs
+++ b/TicketAvailability.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/TicketAvailability.Tests/SeatGrainTests.cs
+++ b/TicketAvailability.Tests/SeatGrainTests.cs
@@ -1,0 +1,59 @@
+using System.Threading.Tasks;
+using Orleans.TestingHost;
+using TicketAvailability.Web.Grains;
+using Xunit;
+
+namespace TicketAvailability.Tests;
+
+public class SeatGrainTests : IClassFixture<ClusterFixture>
+{
+    private readonly TestCluster _cluster;
+    public SeatGrainTests(ClusterFixture fixture)
+    {
+        _cluster = fixture.Cluster;
+    }
+
+    [Fact]
+    public async Task Seat_Is_Available_Initially()
+    {
+        var grain = _cluster.GrainFactory.GetGrain<ISeatGrain>("event1-seat1");
+        var available = await grain.IsAvailable();
+        Assert.True(available);
+    }
+
+    [Fact]
+    public async Task Locking_Same_Seat_Twice_Fails()
+    {
+        var grain = _cluster.GrainFactory.GetGrain<ISeatGrain>("event1-seat2");
+        var first = await grain.TryLockSeat();
+        var second = await grain.TryLockSeat();
+        Assert.True(first);
+        Assert.False(second);
+    }
+}
+
+public class ClusterFixture : IDisposable
+{
+    public TestCluster Cluster { get; }
+
+    public ClusterFixture()
+    {
+        var builder = new TestClusterBuilder(1);
+        builder.AddSiloBuilderConfigurator<SiloConfigurator>();
+        Cluster = builder.Build();
+        Cluster.Deploy();
+    }
+
+    public void Dispose()
+    {
+        Cluster?.StopAllSilos();
+    }
+}
+
+public class SiloConfigurator : ISiloConfigurator
+{
+    public void Configure(ISiloBuilder siloBuilder)
+    {
+        siloBuilder.AddMemoryGrainStorage("Default");
+    }
+}

--- a/TicketAvailability.Tests/SeatLockIntegrationTests.cs
+++ b/TicketAvailability.Tests/SeatLockIntegrationTests.cs
@@ -1,0 +1,29 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Orleans.TestingHost;
+using TicketAvailability.Web.Grains;
+using Xunit;
+
+namespace TicketAvailability.Tests;
+
+public class SeatLockIntegrationTests : IClassFixture<ClusterFixture>
+{
+    private readonly TestCluster _cluster;
+    public SeatLockIntegrationTests(ClusterFixture fixture)
+    {
+        _cluster = fixture.Cluster;
+    }
+
+    [Fact]
+    public async Task Only_One_Succeeds_Under_Contention()
+    {
+        var tasks = Enumerable.Range(0, 10).Select(async _ =>
+        {
+            var grain = _cluster.GrainFactory.GetGrain<ISeatGrain>("event2-seat1");
+            return await grain.TryLockSeat();
+        });
+
+        var results = await Task.WhenAll(tasks);
+        Assert.Equal(1, results.Count(r => r));
+    }
+}

--- a/TicketAvailability.Tests/TicketAvailability.Tests.csproj
+++ b/TicketAvailability.Tests/TicketAvailability.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="7.2.5" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TicketAvailability.Web\TicketAvailability.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/TicketAvailability.Web/Grains/ISeatGrain.cs
+++ b/TicketAvailability.Web/Grains/ISeatGrain.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Orleans;
+
+namespace TicketAvailability.Web.Grains
+{
+    public interface ISeatGrain : IGrainWithStringKey
+    {
+        Task<bool> TryLockSeat();
+        Task UnlockSeat();
+        Task<bool> IsAvailable();
+    }
+}

--- a/TicketAvailability.Web/Grains/SeatGrain.cs
+++ b/TicketAvailability.Web/Grains/SeatGrain.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Orleans;
+
+namespace TicketAvailability.Web.Grains
+{
+    public class SeatGrain : Grain, ISeatGrain
+    {
+        private bool _locked;
+
+        public Task<bool> IsAvailable() => Task.FromResult(!_locked);
+
+        public Task UnlockSeat()
+        {
+            _locked = false;
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> TryLockSeat()
+        {
+            if (_locked)
+            {
+                return Task.FromResult(false);
+            }
+            _locked = true;
+            return Task.FromResult(true);
+        }
+    }
+}

--- a/TicketAvailability.Web/Program.cs
+++ b/TicketAvailability.Web/Program.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Caching.Memory;
+using Orleans.Hosting;
+using TicketAvailability.Web.Grains;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddMemoryCache();
+
+builder.Host.UseOrleans(siloBuilder =>
+{
+    siloBuilder.UseLocalhostClustering();
+    siloBuilder.AddMemoryGrainStorage("Default");
+});
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapGet("/seats/{eventId}/{seatId}", async (IGrainFactory grains, IMemoryCache cache, string eventId, string seatId) =>
+{
+    var key = $"{eventId}-{seatId}";
+    if (!cache.TryGetValue(key, out bool available))
+    {
+        var grain = grains.GetGrain<ISeatGrain>(key);
+        available = await grain.IsAvailable();
+        cache.Set(key, available);
+    }
+    return Results.Ok(new { SeatId = seatId, Available = available });
+});
+
+app.MapPost("/seats/{eventId}/{seatId}/lock", async (IGrainFactory grains, IMemoryCache cache, string eventId, string seatId) =>
+{
+    var key = $"{eventId}-{seatId}";
+    var grain = grains.GetGrain<ISeatGrain>(key);
+    var success = await grain.TryLockSeat();
+    cache.Set(key, false);
+    return success ? Results.Ok() : Results.Conflict();
+});
+
+app.MapPost("/seats/{eventId}/{seatId}/unlock", async (IGrainFactory grains, IMemoryCache cache, string eventId, string seatId) =>
+{
+    var key = $"{eventId}-{seatId}";
+    var grain = grains.GetGrain<ISeatGrain>(key);
+    await grain.UnlockSeat();
+    cache.Set(key, true);
+    return Results.Ok();
+});
+
+app.Run();

--- a/TicketAvailability.Web/Properties/launchSettings.json
+++ b/TicketAvailability.Web/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:23050",
+      "sslPort": 44319
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5086",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7257;http://localhost:5086",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/TicketAvailability.Web/TicketAvailability.Web.csproj
+++ b/TicketAvailability.Web/TicketAvailability.Web.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="7.2.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/TicketAvailability.Web/TicketAvailability.Web.http
+++ b/TicketAvailability.Web/TicketAvailability.Web.http
@@ -1,0 +1,6 @@
+@TicketAvailability.Web_HostAddress = http://localhost:5086
+
+GET {{TicketAvailability.Web_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/TicketAvailability.Web/appsettings.Development.json
+++ b/TicketAvailability.Web/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/TicketAvailability.Web/appsettings.json
+++ b/TicketAvailability.Web/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/TicketAvailability.sln
+++ b/TicketAvailability.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TicketAvailability.Web", "TicketAvailability.Web\TicketAvailability.Web.csproj", "{604547B5-F9F8-4FFF-8D91-A0F691FEE5AE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TicketAvailability.Tests", "TicketAvailability.Tests\TicketAvailability.Tests.csproj", "{8E8F59C7-D811-4E1B-84D4-D949632138B3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{604547B5-F9F8-4FFF-8D91-A0F691FEE5AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{604547B5-F9F8-4FFF-8D91-A0F691FEE5AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{604547B5-F9F8-4FFF-8D91-A0F691FEE5AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{604547B5-F9F8-4FFF-8D91-A0F691FEE5AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8E8F59C7-D811-4E1B-84D4-D949632138B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E8F59C7-D811-4E1B-84D4-D949632138B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E8F59C7-D811-4E1B-84D4-D949632138B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E8F59C7-D811-4E1B-84D4-D949632138B3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- add Orleans-based ASP.NET web API for seat availability
- cache availability in-memory and expose endpoints for lock/unlock
- implement seat grain to coordinate locks
- add unit and integration tests using TestCluster
- document how to run the web app and tests

## Testing
- `dotnet build TicketAvailability.sln -c Release`
- `dotnet test TicketAvailability.sln`

------
https://chatgpt.com/codex/tasks/task_e_684042fdd000832ebed1f266a30ae8e9