### PR TITLE
Add large venue tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,17 @@ dotnet test TicketAvailability.sln
 ```
 
 The tests include scenarios with high contention to ensure only one lock succeeds when many requests compete for the same seat.
+
+## Large venues
+
+The tests include cases that load thousands of `SeatGrain` instances to simulate very large venues. Each seat is activated in the silo and verified to be available and lockable. This demonstrates that Orleans can manage many grains in memory without additional infrastructure.
+
+## Architecture
+
+```mermaid
+graph TD
+    A[ASP.NET Core Web API] -->|uses| B{Orleans Silo}
+    B --> C[SeatGrain]
+    B --> D[In-memory Grain Storage]
+    A --> E[Memory Cache]
+```

--- a/TicketAvailability.Tests/LargeVenueTests.cs
+++ b/TicketAvailability.Tests/LargeVenueTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Orleans.TestingHost;
+using TicketAvailability.Web.Grains;
+using Xunit;
+
+namespace TicketAvailability.Tests;
+
+public class LargeVenueTests : IClassFixture<ClusterFixture>
+{
+    private readonly TestCluster _cluster;
+    public LargeVenueTests(ClusterFixture fixture)
+    {
+        _cluster = fixture.Cluster;
+    }
+
+    [Theory]
+    [InlineData(1000)]
+    [InlineData(5000)]
+    public async Task Seats_For_Large_Venue_Can_Be_Loaded(int seatCount)
+    {
+        var tasks = Enumerable.Range(1, seatCount).Select(async i =>
+        {
+            var grain = _cluster.GrainFactory.GetGrain<ISeatGrain>($"bigEvent-seat{i}");
+            return await grain.IsAvailable();
+        });
+
+        var results = await Task.WhenAll(tasks);
+        Assert.All(results, Assert.True);
+    }
+
+    [Fact]
+    public async Task All_Seats_Can_Be_Locked_Independently()
+    {
+        const int seatCount = 1000;
+        var tasks = Enumerable.Range(1, seatCount).Select(async i =>
+        {
+            var grain = _cluster.GrainFactory.GetGrain<ISeatGrain>($"bigEvent2-seat{i}");
+            return await grain.TryLockSeat();
+        });
+
+        var results = await Task.WhenAll(tasks);
+        Assert.All(results, Assert.True);
+    }
+}


### PR DESCRIPTION
## Summary
- add `LargeVenueTests` to stress Orleans with thousands of seat grains
- document the large venue scenario
- include a simple architecture diagram in the README

## Testing
- `dotnet test TicketAvailability.sln --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404476ded0832eac6076343cb337b8